### PR TITLE
Add basic ChallengeList

### DIFF
--- a/src/app/(tabs)/allChallenges.tsx
+++ b/src/app/(tabs)/allChallenges.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import ChallengeList from '../../components/challenge/ChallengeList';
+import { useMusicStore, selectChallenges } from '../../stores/musicStore';
+import { SAMPLE_CHALLENGES } from '../../constants/theme';
+import type { MusicChallenge } from '../../types';
+import { router } from 'expo-router';
+
+export default function ChallengesScreen() {
+  const challenges = useMusicStore(selectChallenges) ?? (SAMPLE_CHALLENGES as MusicChallenge[]);
+
+  const handleSelect = async (c: MusicChallenge) => {
+    router.push(`/(modals)/player?id=${c.id}`);
+  };
+
+  return (
+    <View style={styles.container}>
+      <ChallengeList
+        challenges={challenges}
+        onSelect={handleSelect}
+        contentContainerStyle={styles.listContainer}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, paddingHorizontal: 16, paddingTop: 24, backgroundColor: '#000' },
+  listContainer: { paddingBottom: 48 },
+});

--- a/src/app/(tabs)/index.tsx
+++ b/src/app/(tabs)/index.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { View, Text, StyleSheet, FlatList } from 'react-native';
 import { router } from 'expo-router';
 import { ChallengeCard } from '../../components/challenge/ChallengeCard';
+import  ChallengeList  from '../../components/challenge/ChallengeList';
 import { useMusicPlayer } from '../../hooks/useMusicPlayer';
 import { useMusicStore, selectChallenges, selectCurrentTrack, selectIsPlaying } from '../../stores/musicStore';
 import { THEME } from '../../constants/theme';

--- a/src/components/challenge/ChallengeList.tsx
+++ b/src/components/challenge/ChallengeList.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { FlatList, StyleProp, ViewStyle } from 'react-native';
+import type { MusicChallenge } from '../../types';
+import { ChallengeCard } from './ChallengeCard';
+
+type Props = {
+  challenges: MusicChallenge[];
+  onSelect: (c: MusicChallenge) => void;
+  onPlay?: (c: MusicChallenge) => void;
+  contentContainerStyle?: StyleProp<ViewStyle>;
+  currentTrackId?: string;
+  isPlaying?: boolean;
+};
+
+export default function ChallengeList({
+  challenges,
+  onSelect,
+  onPlay,
+  contentContainerStyle,
+  currentTrackId,
+  isPlaying,
+}: Props) {
+  return (
+    <FlatList
+      data={challenges}
+      keyExtractor={(i) => i.id}
+      contentContainerStyle={contentContainerStyle}
+      renderItem={({ item }) => (
+        <ChallengeCard
+          challenge={item}
+          onPlay={onPlay ?? onSelect}
+        //   onPress={() => onSelect(item)}
+          isCurrentTrack={item.id === currentTrackId}
+          isPlaying={isPlaying}
+        />
+      )}
+      showsVerticalScrollIndicator={false}
+    />
+  );
+}


### PR DESCRIPTION
## 🧩 Add ChallengeList Component

This PR introduces the `ChallengeList` component and integrates it into the app's tab navigation.

### ✨ What's Added
- `ChallengeList.tsx`: A reusable component that renders a list of `ChallengeCard`s using `FlatList`
- `ChallengesScreen`: New screen under `(tabs)/allChallenges.tsx` that displays the challenge list
- Integration with `musicStore` to fetch challenges from state or fallback to sample data
- Navigation to player modal on challenge selection

### 🛠️ Technical Notes
- Uses `router.push` to navigate to `/(modals)/player?id={challenge.id}`
- Applies consistent padding and background styling
- Supports custom `contentContainerStyle` for layout flexibility

---

> ⚠️ **Disclaimer:** This feature is still a work in progress.  
> Some UI elements and interactions may be incomplete or subject to change.  
> Feedback and suggestions are welcome!

✅ Ready to merge — no breaking changes introduced. 
